### PR TITLE
Feat/feeder custom feed crud

### DIFF
--- a/cypress/e2e/feeder-custom-feed.cy.ts
+++ b/cypress/e2e/feeder-custom-feed.cy.ts
@@ -1,0 +1,57 @@
+describe("Feeder Custom Feed", () => {
+  beforeEach(() => {
+    cy.login(Cypress.env("TEST_PRX_USER"), Cypress.env("TEST_PRX_PASS"));
+    Cypress.config({ baseUrl: `https://${Cypress.env("FEEDER_HOST")}` });
+  });
+
+  it("creates a new custom feed", () => {
+    const now = new Date().toISOString();
+    const canary = `Acceptance Test: ${now}`;
+    // const audioFile = "cypress/samples/two-tone.mp3";
+    const imageFile = "cypress/samples/1400.jpg";
+
+    cy.visit("/podcasts");
+    cy.contains("My Podcasts");
+
+    // create a new podcast
+    cy.get('a.btn-success[href="/podcasts/new"]').click();
+    cy.contains("New Podcast");
+    cy.get("#podcast_title").type(canary);
+    cy.get("#podcast_default_feed_attributes_itunes_category").select("Business", { force: true });
+    cy.get("#podcast_default_feed_attributes_itunes_subcategory").select("Careers", {
+      force: true,
+    });
+    cy.contains(".btn", "Create").click();
+    cy.contains("Podcast created");
+
+    // go to feeds and add a new custom feed
+    cy.contains("a", "Feeds").click();
+    cy.contains(".btn", "Add a Feed").click();
+    cy.get("#feed_title").type(canary);
+    cy.get("#feed_slug").type("customslug");
+    cy.contains(".btn", "Create").click();
+    cy.contains("Feed created");
+
+    // update and make it a private feed
+    cy.get("#feed_private").click();
+    cy.contains(".btn", "Add Token").click();
+    cy.get("[id^=feed_feed_tokens]").first().type("newtoken");
+    cy.contains(".btn", "Save").click();
+
+    // delete the custom feed
+    cy.contains(".btn", "Save").next(".dropdown-toggle").click();
+    cy.contains(".dropdown-item", "Delete").click();
+    cy.contains("Really Delete?");
+    cy.contains(".btn", "Delete").click();
+    cy.contains("Feed deleted");
+
+    // go back to podcast settings and delete
+    cy.contains("a", "Settings").click({ force: true });
+    cy.get("#podcast_title");
+    cy.contains(".btn", "Save").next(".dropdown-toggle").click();
+    cy.contains(".dropdown-item", "Delete").click();
+    cy.contains("Really Delete?");
+    cy.contains(".btn", "Delete").click();
+    cy.contains("Podcast deleted");
+  });
+});

--- a/cypress/e2e/feeder-custom-feed.cy.ts
+++ b/cypress/e2e/feeder-custom-feed.cy.ts
@@ -7,8 +7,6 @@ describe("Feeder Custom Feed", () => {
   it("creates a new custom feed", () => {
     const now = new Date().toISOString();
     const canary = `Acceptance Test: ${now}`;
-    // const audioFile = "cypress/samples/two-tone.mp3";
-    const imageFile = "cypress/samples/1400.jpg";
 
     cy.visit("/podcasts");
     cy.contains("My Podcasts");

--- a/cypress/e2e/feeder-custom-feed.cy.ts
+++ b/cypress/e2e/feeder-custom-feed.cy.ts
@@ -35,6 +35,7 @@ describe("Feeder Custom Feed", () => {
     cy.contains(".btn", "Add Token").click();
     cy.get("[id^=feed_feed_tokens]").first().type("newtoken");
     cy.contains(".btn", "Save").click();
+    cy.contains("Feed updated");
 
     // delete the custom feed
     cy.contains(".btn", "Save").next(".dropdown-toggle").click();


### PR DESCRIPTION
resolves #4 and will conclude this initial chunk of feeder acceptance tests assigned to me. there is one more test suggestion listed in the ticket that @cavis made in a Slack thread, however if it is not urgent i would like to move that into its own ticket or bundle that with other relevant acceptance-test work in favor of closing this year old ticket.

This PR adds a new test file for testing CRUD actions for a custom feed, focusing on the following steps:

1. create a podcast
2. create a new custom feed for that podcast
3. update the feed with some new attributes
4. delete the feed
5. delete the podcast

if there are other steps specific to feeds that should be included, please let me know.

tagging @cavis or @farski for code review, no preference on who takes it.